### PR TITLE
feat: add support for hotplugging and multiple Stream Decks

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ If that fails (**or if you are on a Raspberry Pi**), you will need to install a 
 some of `node-elgato-stream-deck`'s dependencies from source. 
 
 * Windows
-  * Install [`windows-build-tools`](https://github.com/felixrieseberg/windows-build-tools) **with all optional libraries**:
+  * Install [`windows-build-tools`](https://github.com/felixrieseberg/windows-build-tools) **with all optional libraries**.
+  This will download **several gigabytes** of files to your system drive/partition, so it may take a long time and use up
+  a lot of space!:
   ```bash
   npm --vcc-build-tools-parameters='[""/Full""]' install --global windows-build-tools
   ```

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ If that fails (**or if you are on a Raspberry Pi**), you will need to install a 
 some of `node-elgato-stream-deck`'s dependencies from source. 
 
 * Windows
-  * Install [`windows-build-tools`](https://github.com/felixrieseberg/windows-build-tools):
+  * Install [`windows-build-tools`](https://github.com/felixrieseberg/windows-build-tools) **with all optional libraries**:
   ```bash
-  npm install --global windows-build-tools
+  npm --vcc-build-tools-parameters='[""/Full""]' install --global windows-build-tools
   ```
 * MacOS
   * Install [Xcode](https://developer.apple.com/xcode/download/), then:
@@ -66,27 +66,29 @@ some of `node-elgato-stream-deck`'s dependencies from source.
 const path = require('path');
 const streamDeck = require('elgato-stream-deck');
 
-streamDeck.on('down', keyIndex => {
+streamDeck.on('down', (device, keyIndex) => {
     console.log('key %d down', keyIndex);
 });
 
-streamDeck.on('up', keyIndex => {
+streamDeck.on('up', (device, keyIndex) => {
     console.log('key %d up', keyIndex);
 });
 
-streamDeck.on('error', error => {
+streamDeck.on('error', (device, error) => {
     console.error(error);
 });
 
-// Fill the second button from the left in the first row with an image of the GitHub logo.
-// This is asynchronous and returns a promise.
-streamDeck.fillImageFromFile(3, path.resolve(__dirname, 'github_logo.png')).then(() => {
-	console.log('Successfully wrote a GitHub logo to key 3.');
+streamDeck.on('connect', device => {
+	// Fill the second button from the left in the first row with an image of the GitHub logo.
+    // This is asynchronous and returns a promise.
+    device.fillImageFromFile(3, path.resolve(__dirname, 'github_logo.png')).then(() => {
+    	console.log('Successfully wrote a GitHub logo to key 3.');
+    });
+    
+    // Fill the first button form the left in the first row with a solid red color. This is synchronous.
+    device.fillColor(4, 255, 0, 0);
+    console.log('Successfully wrote a red square to key 4.');
 });
-
-// Fill the first button form the left in the first row with a solid red color. This is synchronous.
-streamDeck.fillColor(4, 255, 0, 0);
-console.log('Successfully wrote a red square to key 4.');
 ```
 
 #### TypeScript
@@ -94,15 +96,15 @@ console.log('Successfully wrote a red square to key 4.');
 ```typescript
 import streamDeck = require('elgato-stream-deck');
 
-streamDeck.on('down', keyIndex => {
+streamDeck.on('down', (device, keyIndex) => {
     console.log('key %d down', keyIndex);
 });
 
-streamDeck.on('up', keyIndex => {
+streamDeck.on('up', (device, keyIndex) => {
     console.log('key %d up', keyIndex);
 });
 
-streamDeck.on('error', error => {
+streamDeck.on('error', (device, error) => {
     console.error(error);
 });
 ```
@@ -111,12 +113,13 @@ streamDeck.on('error', error => {
 
 * Miltiplatform support: Windows 7-10, MacOS, Linux, and even Raspberry Pi!
 * Key `down` and key `up` events
+* `connect` and `disconnect` events
+* Multiple Stream Decks at once
 * Fill keys with images or solid RGB colors
 * Typescript support
 
 ### Planned Features
 
-* [Hotplugging](https://github.com/Lange/node-elgato-stream-deck/issues/14)
 * [Key combinations](https://github.com/Lange/node-elgato-stream-deck/issues/9)
 * Support "pages" feature from the official Elgato Stream Deck software
 * [Text labels](https://github.com/Lange/node-elgato-stream-deck/issues/6)
@@ -217,7 +220,7 @@ Fired whenever a key is pressed. `keyIndex` is the 0-14 numerical index of that 
 ##### Example
 
 ```javascript
-streamDeck.on('down', keyIndex => {
+streamDeck.on('down', (device, keyIndex) => {
     console.log('key %d down', keyIndex);
 });
 ```
@@ -229,7 +232,7 @@ Fired whenever a key is released. `keyIndex` is the 0-14 numerical index of that
 ##### Example
 
 ```javascript
-streamDeck.on('up', keyIndex => {
+streamDeck.on('up', (device, keyIndex) => {
     console.log('key %d up', keyIndex);
 });
 ```
@@ -242,7 +245,7 @@ Fired whenever an error is detected by the `node-hid` library.
 ##### Example
 
 ```javascript
-streamDeck.on('error', error => {
+streamDeck.on('error', (device, error) => {
     console.error(error);
 });
 ```

--- a/examples/fill-button-when-pressed.js
+++ b/examples/fill-button-when-pressed.js
@@ -3,17 +3,17 @@
 const path = require('path');
 const streamDeck = require('../index');
 
-streamDeck.on('down', keyIndex => {
+streamDeck.on('down', (device, keyIndex) => {
 	// Fill the pressed key with an image of the GitHub logo.
-	streamDeck.fillImageFromFile(keyIndex, path.resolve(__dirname, 'github_logo.png'))
+	device.fillImageFromFile(keyIndex, path.resolve(__dirname, 'github_logo.png'))
 		.catch(error => {
 			console.error(error);
 		});
 });
 
-streamDeck.on('up', keyIndex => {
+streamDeck.on('up', (device, keyIndex) => {
 	// Clear the key when it is released.
-	streamDeck.clearKey(keyIndex);
+	device.clearKey(keyIndex);
 });
 
 streamDeck.on('error', error => {

--- a/examples/rapid-fill.js
+++ b/examples/rapid-fill.js
@@ -2,18 +2,33 @@
 
 const streamDeck = require('../index');
 
-streamDeck.on('error', error => {
-	console.error(error);
+streamDeck.on('connect', device => {
+	console.log('Stream Deck connected');
+	const interval = setInterval(() => {
+		const r = getRandomIntInclusive(0, 255);
+		const g = getRandomIntInclusive(0, 255);
+		const b = getRandomIntInclusive(0, 255);
+		for (let i = 0; i < 15; i++) {
+			try {
+				device.fillColor(i, r, g, b);
+			} catch (e) {
+				clearInterval(interval);
+
+				if (e.message === 'Cannot write to HID device') {
+					console.error('Stream Deck disconnected');
+				} else {
+					console.error(e);
+				}
+
+				break;
+			}
+		}
+	}, 1000 / 5);
 });
 
-setInterval(() => {
-	const r = getRandomIntInclusive(0, 255);
-	const g = getRandomIntInclusive(0, 255);
-	const b = getRandomIntInclusive(0, 255);
-	for (let i = 0; i < 15; i++) {
-		streamDeck.fillColor(i, r, g, b);
-	}
-}, 1000 / 5);
+streamDeck.on('error', (device, error) => {
+	console.error(error);
+});
 
 function getRandomIntInclusive(min, max) {
 	min = Math.ceil(min);

--- a/examples/text-generation.js
+++ b/examples/text-generation.js
@@ -9,8 +9,8 @@ const streamDeck = require('../index');
 const font = PImage.registerFont(path.resolve(__dirname, 'SourceSansPro-Regular.ttf'), 'Source Sans Pro');
 font.loadSync();
 
-streamDeck.on('down', keyIndex => {
-	const img = PImage.make(streamDeck.ICON_SIZE, streamDeck.ICON_SIZE, {fillval: 0x00000000});
+streamDeck.on('down', (device, keyIndex) => {
+	const img = PImage.make(device.ICON_SIZE, device.ICON_SIZE, {fillval: 0x00000000});
 	const ctx = img.getContext('2d');
 	ctx.setFont('Source Sans Pro', 16);
 	ctx.USE_FONT_GLYPH_CACHING = false;
@@ -41,7 +41,7 @@ streamDeck.on('down', keyIndex => {
 		// then put that PNG back into Sharp, flatten it, and render raw.
 		// Seems like a bug in Sharp that we should make a test case for and report.
 		sharp(path.resolve(__dirname, 'github_logo.png'))
-			.resize(streamDeck.ICON_SIZE)
+			.resize(device.ICON_SIZE)
 			.overlayWith(writableStreamBuffer.getContents())
 			.png()
 			.toBuffer()
@@ -49,7 +49,7 @@ streamDeck.on('down', keyIndex => {
 				return sharp(buffer).flatten().raw().toBuffer();
 			})
 			.then(buffer => {
-				return streamDeck.fillImage(keyIndex, buffer);
+				return device.fillImage(keyIndex, buffer);
 			})
 			.catch(error => {
 				console.error(error);
@@ -57,11 +57,11 @@ streamDeck.on('down', keyIndex => {
 	});
 });
 
-streamDeck.on('up', keyIndex => {
+streamDeck.on('up', (device, keyIndex) => {
 	// Clear the key when it is released.
-	streamDeck.clearKey(keyIndex);
+	device.clearKey(keyIndex);
 });
 
-streamDeck.on('error', error => {
+streamDeck.on('error', (device, error) => {
 	console.error(error);
 });

--- a/index.js
+++ b/index.js
@@ -1,155 +1,67 @@
 'use strict';
 
+const PRODUCT_ID = 0x0060;
+const VENDOR_ID = 0x0fd9;
+
 // Native
 const EventEmitter = require('events');
+const emitter = new EventEmitter();
 
 // Packages
 const HID = require('node-hid');
-const sharp = require('sharp');
+const usbDetect = require('usb-detection');
 
-const NUM_KEYS = 15;
-const PAGE_PACKET_SIZE = 8191;
-const NUM_FIRST_PAGE_PIXELS = 2583;
-const NUM_SECOND_PAGE_PIXELS = 2601;
-const ICON_SIZE = 72;
-const NUM_TOTAL_PIXELS = NUM_FIRST_PAGE_PIXELS + NUM_SECOND_PAGE_PIXELS;
+// Ours
+const StreamDeck = require('./lib/StreamDeck');
 
-const devices = HID.devices();
-const connectedStreamDecks = devices.filter(device => {
-	return device.vendorId === 0x0fd9 && device.productId === 0x0060;
+const streamDeckMap = new Map();
+emitter.connectedStreamDecks = streamDeckMap;
+
+usbDetect.find(VENDOR_ID, PRODUCT_ID, err => {
+	if (err) {
+		emitter.emit('error', err);
+		return;
+	}
+
+	refreshStreamDecks();
 });
 
-/* istanbul ignore if  */
-if (connectedStreamDecks.length > 1) {
-	throw new Error('More than one Stream Deck is connected. This is unsupported at this time.');
-}
+usbDetect.on(`add:${VENDOR_ID}:${PRODUCT_ID}`, () => {
+	refreshStreamDecks();
+});
 
-/* istanbul ignore if  */
-if (connectedStreamDecks.length < 1) {
-	throw new Error('No Stream Decks are connected.');
-}
+process.on('exit', () => {
+	usbDetect.stopMonitoring();
+});
 
-class StreamDeck extends EventEmitter {
-	constructor(device) {
-		super();
-		this.device = device;
-		this.keyState = new Array(NUM_KEYS).fill(false);
+emitter.getDevice = function (index) {
+	return Array.from(streamDeckMap.values())[index];
+};
 
-		this.device.on('data', data => {
-			// The first byte is a report ID, the last byte appears to be padding
-			// strip these out for now.
-			data = data.slice(1, data.length - 1);
+function refreshStreamDecks() {
+	const devices = HID.devices();
+	const connectedStreamDecks = devices.filter(device => {
+		return device.vendorId === 0x0fd9 && device.productId === 0x0060;
+	});
 
-			for (let i = 0; i < NUM_KEYS; i++) {
-				const keyPressed = Boolean(data[i]);
-				if (keyPressed !== this.keyState[i]) {
-					if (keyPressed) {
-						this.emit('down', i);
-					} else {
-						this.emit('up', i);
-					}
-				}
+	connectedStreamDecks.forEach(device => {
+		if (streamDeckMap.has(device.path)) {
+			return;
+		}
 
-				this.keyState[i] = keyPressed;
+		const streamDeck = new StreamDeck(new HID.HID(device.path));
+		streamDeck.on('*', function () {
+			if (this.event === 'disconnect') {
+				streamDeckMap.delete(device.path);
 			}
+
+			emitter.emit(this.event, streamDeck, ...arguments);
 		});
 
-		this.device.on('error', err => {
-			this.emit('error', err);
-		});
-	}
+		streamDeckMap.set(device.path, streamDeck);
 
-	write(buffer) {
-		return this.device.write(StreamDeck.bufferToIntArray(buffer));
-	}
-
-	fillColor(keyIndex, r, g, b) {
-		const pixel = Buffer.from([b, g, r]);
-		this._writePage1(keyIndex, Buffer.alloc(NUM_FIRST_PAGE_PIXELS * 3, pixel));
-		this._writePage2(keyIndex, Buffer.alloc(NUM_SECOND_PAGE_PIXELS * 3, pixel));
-	}
-
-	fillImage(keyIndex, imageBuffer) {
-		if (imageBuffer.length !== 15552) {
-			throw new Error(`Expected image buffer of length 15552, got length ${imageBuffer.length}`);
-		}
-
-		let pixels = [];
-		for (let r = 0; r < ICON_SIZE; r++) {
-			const row = [];
-			const start = r * 3 * ICON_SIZE;
-			for (let i = start; i < start + (ICON_SIZE * 3); i += 3) {
-				const r = imageBuffer.readUInt8(i);
-				const g = imageBuffer.readUInt8(i + 1);
-				const b = imageBuffer.readUInt8(i + 2);
-				row.push(b, g, r);
-			}
-			pixels = pixels.concat(row.reverse());
-		}
-
-		const firstPagePixels = pixels.slice(0, NUM_FIRST_PAGE_PIXELS * 3);
-		const secondPagePixels = pixels.slice(NUM_FIRST_PAGE_PIXELS * 3, NUM_TOTAL_PIXELS * 3);
-		this._writePage1(keyIndex, Buffer.from(firstPagePixels));
-		this._writePage2(keyIndex, Buffer.from(secondPagePixels));
-	}
-
-	fillImageFromFile(keyIndex, filePath) {
-		return sharp(filePath)
-			.flatten() // Eliminate alpha channel, if any.
-			.resize(this.ICON_SIZE)
-			.raw()
-			.toBuffer()
-			.then(buffer => {
-				return this.fillImage(keyIndex, buffer);
-			});
-	}
-
-	clearKey(keyIndex) {
-		return this.fillColor(keyIndex, 0, 0, 0);
-	}
-
-	_writePage1(keyIndex, buffer) {
-		const header = Buffer.from([
-			0x02, 0x01, 0x01, 0x00, 0x00, keyIndex + 1, 0x00, 0x00,
-			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-			0x42, 0x4d, 0xf6, 0x3c, 0x00, 0x00, 0x00, 0x00,
-			0x00, 0x00, 0x36, 0x00, 0x00, 0x00, 0x28, 0x00,
-			0x00, 0x00, 0x48, 0x00, 0x00, 0x00, 0x48, 0x00,
-			0x00, 0x00, 0x01, 0x00, 0x18, 0x00, 0x00, 0x00,
-			0x00, 0x00, 0xc0, 0x3c, 0x00, 0x00, 0xc4, 0x0e,
-			0x00, 0x00, 0xc4, 0x0e, 0x00, 0x00, 0x00, 0x00,
-			0x00, 0x00, 0x00, 0x00, 0x00, 0x00
-		]);
-
-		const packet = this._padToLength(Buffer.concat([header, buffer]), PAGE_PACKET_SIZE);
-		return this.write(packet);
-	}
-
-	_writePage2(keyIndex, buffer) {
-		const header = Buffer.from([0x02, 0x01, 0x02, 0x00, 0x01, keyIndex + 1]);
-		const packet = this._padToLength(Buffer.concat([header, this._pad(10), buffer]), PAGE_PACKET_SIZE);
-		return this.write(packet);
-	}
-
-	_padToLength(buffer, padLength) {
-		return Buffer.concat([buffer, this._pad(padLength - buffer.length)]);
-	}
-
-	_pad(padLength) {
-		return Buffer.alloc(padLength);
-	}
-
-	get ICON_SIZE() {
-		return ICON_SIZE;
-	}
-
-	static bufferToIntArray(buffer) {
-		const array = [];
-		for (const pair of buffer.entries()) {
-			array.push(pair[1]);
-		}
-		return array;
-	}
+		emitter.emit('connect', streamDeck);
+	});
 }
 
-module.exports = new StreamDeck(new HID.HID(connectedStreamDecks[0].path));
+module.exports = emitter;

--- a/lib/StreamDeck.js
+++ b/lib/StreamDeck.js
@@ -1,0 +1,144 @@
+'use strict';
+
+const NUM_KEYS = 15;
+const PAGE_PACKET_SIZE = 8191;
+const NUM_FIRST_PAGE_PIXELS = 2583;
+const NUM_SECOND_PAGE_PIXELS = 2601;
+const ICON_SIZE = 72;
+const NUM_TOTAL_PIXELS = NUM_FIRST_PAGE_PIXELS + NUM_SECOND_PAGE_PIXELS;
+
+// Native
+const EventEmitter2 = require('eventemitter2').EventEmitter2;
+
+// Packages
+const sharp = require('sharp');
+
+class StreamDeck extends EventEmitter2 {
+	constructor(device) {
+		super({wildcard: true});
+		this.device = device;
+		this.keyState = new Array(NUM_KEYS).fill(false);
+
+		this.device.on('data', data => {
+			// The first byte is a report ID, the last byte appears to be padding
+			// strip these out for now.
+			data = data.slice(1, data.length - 1);
+
+			for (let i = 0; i < NUM_KEYS; i++) {
+				const keyPressed = Boolean(data[i]);
+				if (keyPressed !== this.keyState[i]) {
+					if (keyPressed) {
+						this.emit('down', i);
+					} else {
+						this.emit('up', i);
+					}
+				}
+
+				this.keyState[i] = keyPressed;
+			}
+		});
+
+		this.device.on('error', err => {
+			if (err.message === 'could not read from HID device') {
+				this.emit('disconnect');
+				return;
+			}
+
+			this.emit('error', err);
+		});
+	}
+
+	write(buffer) {
+		return this.device.write(StreamDeck.bufferToIntArray(buffer));
+	}
+
+	fillColor(keyIndex, r, g, b) {
+		const pixel = Buffer.from([b, g, r]);
+		this._writePage1(keyIndex, Buffer.alloc(NUM_FIRST_PAGE_PIXELS * 3, pixel));
+		this._writePage2(keyIndex, Buffer.alloc(NUM_SECOND_PAGE_PIXELS * 3, pixel));
+	}
+
+	fillImage(keyIndex, imageBuffer) {
+		if (imageBuffer.length !== 15552) {
+			throw new Error(`Expected image buffer of length 15552, got length ${imageBuffer.length}`);
+		}
+
+		let pixels = [];
+		for (let r = 0; r < ICON_SIZE; r++) {
+			const row = [];
+			const start = r * 3 * ICON_SIZE;
+			for (let i = start; i < start + (ICON_SIZE * 3); i += 3) {
+				const r = imageBuffer.readUInt8(i);
+				const g = imageBuffer.readUInt8(i + 1);
+				const b = imageBuffer.readUInt8(i + 2);
+				row.push(b, g, r);
+			}
+			pixels = pixels.concat(row.reverse());
+		}
+
+		const firstPagePixels = pixels.slice(0, NUM_FIRST_PAGE_PIXELS * 3);
+		const secondPagePixels = pixels.slice(NUM_FIRST_PAGE_PIXELS * 3, NUM_TOTAL_PIXELS * 3);
+		this._writePage1(keyIndex, Buffer.from(firstPagePixels));
+		this._writePage2(keyIndex, Buffer.from(secondPagePixels));
+	}
+
+	fillImageFromFile(keyIndex, filePath) {
+		return sharp(filePath)
+			.flatten() // Eliminate alpha channel, if any.
+			.resize(this.ICON_SIZE)
+			.raw()
+			.toBuffer()
+			.then(buffer => {
+				return this.fillImage(keyIndex, buffer);
+			});
+	}
+
+	clearKey(keyIndex) {
+		return this.fillColor(keyIndex, 0, 0, 0);
+	}
+
+	_writePage1(keyIndex, buffer) {
+		const header = Buffer.from([
+			0x02, 0x01, 0x01, 0x00, 0x00, keyIndex + 1, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			0x42, 0x4d, 0xf6, 0x3c, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x36, 0x00, 0x00, 0x00, 0x28, 0x00,
+			0x00, 0x00, 0x48, 0x00, 0x00, 0x00, 0x48, 0x00,
+			0x00, 0x00, 0x01, 0x00, 0x18, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0xc0, 0x3c, 0x00, 0x00, 0xc4, 0x0e,
+			0x00, 0x00, 0xc4, 0x0e, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+		]);
+
+		const packet = this._padToLength(Buffer.concat([header, buffer]), PAGE_PACKET_SIZE);
+		return this.write(packet);
+	}
+
+	_writePage2(keyIndex, buffer) {
+		const header = Buffer.from([0x02, 0x01, 0x02, 0x00, 0x01, keyIndex + 1]);
+		const packet = this._padToLength(Buffer.concat([header, this._pad(10), buffer]), PAGE_PACKET_SIZE);
+		return this.write(packet);
+	}
+
+	_padToLength(buffer, padLength) {
+		return Buffer.concat([buffer, this._pad(padLength - buffer.length)]);
+	}
+
+	_pad(padLength) {
+		return Buffer.alloc(padLength);
+	}
+
+	get ICON_SIZE() {
+		return ICON_SIZE;
+	}
+
+	static bufferToIntArray(buffer) {
+		const array = [];
+		for (const pair of buffer.entries()) {
+			array.push(pair[1]);
+		}
+		return array;
+	}
+}
+
+module.exports = StreamDeck;

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "sharp": "^0.17.3",
     "sinon": "^2.2.0",
     "stream-buffers": "^3.0.1",
+    "uuid": "^3.0.1",
     "weallbehave": "^1.2.0",
     "weallcontribute": "^1.0.8"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "typings": "typings.d.ts",
   "dependencies": {
-    "node-hid": "^0.5.4"
+    "node-hid": "^0.5.4",
+    "usb-detection": "^1.4.0"
   },
   "devDependencies": {
     "ava": "^0.19.1",

--- a/test/fixtures/mock-modules/node-hid.js
+++ b/test/fixtures/mock-modules/node-hid.js
@@ -1,0 +1,26 @@
+'use strict';
+
+// Native
+const EventEmitter = require('events');
+
+// Packages
+const sinon = require('sinon');
+const uuidV4 = require('uuid/v4');
+
+class MockHID extends EventEmitter {
+	constructor() {
+		super();
+		this.write = sinon.spy();
+	}
+}
+
+module.exports = {
+	devices() {
+		return [{
+			vendorId: 0x0fd9,
+			productId: 0x0060,
+			path: uuidV4()
+		}];
+	},
+	HID: MockHID
+};

--- a/test/fixtures/mock-modules/usb-detection.js
+++ b/test/fixtures/mock-modules/usb-detection.js
@@ -1,0 +1,16 @@
+'use strict';
+
+// Native
+const EventEmitter = require('events');
+
+class MockUSBDetection extends EventEmitter {
+	find(vid, pid, cb) {
+		process.nextTick(cb);
+	}
+
+	stopMonitoring() {
+
+	}
+}
+
+module.exports = new MockUSBDetection();

--- a/wallaby.js
+++ b/wallaby.js
@@ -1,6 +1,7 @@
 module.exports = {
 	files: [
 		'*.js',
+		'lib/**/*.js',
 		'test/fixtures/**'
 	],
 

--- a/wallaby.js
+++ b/wallaby.js
@@ -2,7 +2,7 @@ module.exports = {
 	files: [
 		'*.js',
 		'lib/**/*.js',
-		'test/fixtures/**'
+		'test/fixtures/**/*.*'
 	],
 
 	tests: [


### PR DESCRIPTION
This is not ready to merge yet.

This PR adds the following:
* Hotplug support
* `connect` and `disconnect` events
* A new event system that sends the relevant `device` along with every event

There's still some problems and things to be done:
* Need to get test coverage back up to 100%
* Some of the new APIs, like `streamDeck.connectedStreamDecks` and `streamDeck.getDevice(index)` could probably use work and better names.
* The overall structure of the API here should be re-revaluated and some things will probably get renamed. Using the word `device` everywhere feels vague and confusing.

Closes #14.