### PR TITLE
Implement a base example of keyCombo events

### DIFF
--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -161,6 +161,24 @@ test('down and up events', t => {
 	t.is(upSpy.getCall(0).args[0], 0);
 });
 
+test('register key combo', t => {
+	const streamDeck = t.context.streamDeck;
+	const downSpy = sinon.spy();
+	const upSpy = sinon.spy();
+
+	const keyCombo = streamDeck.registerKeyCombo([0, 1]);
+
+	keyCombo.on('down', key => downSpy(key));
+	keyCombo.on('up', key => upSpy(key));
+	streamDeck.device.emit('data', Buffer.from([0x01, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]));
+	streamDeck.device.emit('data', Buffer.from([0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]));
+
+	t.is(downSpy.getCall(0).args[0][0], 0);
+	t.is(downSpy.getCall(0).args[0][1], 1);
+	t.is(upSpy.getCall(0).args[0][0], 0);
+	t.is(upSpy.getCall(0).args[0][1], 1);
+});
+
 test.cb('forwards error events from the device', t => {
 	const streamDeck = t.context.streamDeck;
 	streamDeck.on('error', () => {


### PR DESCRIPTION
@Lange before you approve this, can you let me know a bit of functionality question?

Currently, the way I implemented it, it will emit 'up' when the keys in that keyCombo are pressed *and* other keys are pressed. Upon the other keys being released, 'down' is emitted again, when *only* the keys in that keyCombo are pressed.

Honestly I don't know what people would prefer, so I wanted to get some input before finalizing it. I'll finish and rebase to a single commit based on what we think.